### PR TITLE
Add new property MediaState.

### DIFF
--- a/src/common/include/meego/proplist-nemo.h
+++ b/src/common/include/meego/proplist-nemo.h
@@ -26,4 +26,11 @@
 #define PA_NEMO_PROP_CALL_STATE_ACTIVE              "active"
 #define PA_NEMO_PROP_CALL_STATE_INACTIVE            "inactive"
 
+#define PA_NEMO_PROP_MEDIA_STATE                    "x-nemo.media.state"
+#define PA_NEMO_PROP_MEDIA_STATE_INACTIVE           "inactive"
+#define PA_NEMO_PROP_MEDIA_STATE_FOREGROUND         "foreground"
+#define PA_NEMO_PROP_MEDIA_STATE_BACKGROUND         "background"
+#define PA_NEMO_PROP_MEDIA_STATE_ACTIVE             "active"
+
+
 #endif /* _PROPLIST_NEMO_H_ */

--- a/src/mainvolume/mainvolume.c
+++ b/src/mainvolume/mainvolume.c
@@ -31,6 +31,7 @@
 
 #include "call-state-tracker.h"
 #include "volume-proxy.h"
+#include "proplist-nemo.h"
 
 #include "mainvolume.h"
 
@@ -307,4 +308,34 @@ bool mv_has_high_volume(struct mv_userdata *u) {
         return true;
     else
         return false;
+}
+
+struct media_state_map {
+    media_state_t state;
+    const char *str;
+};
+
+static struct media_state_map media_states[MEDIA_MAX] = {
+    { MEDIA_INACTIVE,   PA_NEMO_PROP_MEDIA_STATE_INACTIVE   },
+    { MEDIA_FOREGROUND, PA_NEMO_PROP_MEDIA_STATE_FOREGROUND },
+    { MEDIA_BACKGROUND, PA_NEMO_PROP_MEDIA_STATE_BACKGROUND },
+    { MEDIA_ACTIVE,     PA_NEMO_PROP_MEDIA_STATE_ACTIVE     }
+};
+
+bool mv_media_state_from_string(const char *str, media_state_t *state) {
+    uint32_t i;
+    for (i = 0; i < MEDIA_MAX; i++) {
+        if (pa_streq(media_states[i].str, str)) {
+            *state = media_states[i].state;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+const char *mv_media_state_from_enum(media_state_t state) {
+    pa_assert(state < MEDIA_MAX);
+
+    return media_states[state].str;
 }

--- a/src/mainvolume/mainvolume.h
+++ b/src/mainvolume/mainvolume.h
@@ -42,6 +42,14 @@
 #define CALL_STREAM "sink-input-by-media-role:phone"
 #define MAX_STEPS (64)
 
+typedef enum media_state {
+    MEDIA_INACTIVE,
+    MEDIA_FOREGROUND,
+    MEDIA_BACKGROUND,
+    MEDIA_ACTIVE,
+    MEDIA_MAX
+} media_state_t;
+
 struct mv_volume_steps {
     int step[MAX_STEPS];
     unsigned n_steps;
@@ -76,6 +84,7 @@ struct mv_userdata {
 
     pa_shared_data *shared;
     pa_hook_slot *call_state_hook_slot;
+    pa_hook_slot *media_state_hook_slot;
     bool call_active;
 
     pa_volume_proxy *volume_proxy;
@@ -113,6 +122,10 @@ struct mv_userdata {
         pa_hashmap *sink_inputs;
         uint32_t enabled_slots; /* bit slots that are enabled */
         uint32_t free_slots;    /* 1 means free, 0 means taken. */
+
+        bool streams_active;                /* Active media streams. */
+        media_state_t policy_media_state;   /* Media state from policy enforcement point of view. */
+        media_state_t media_state;          /* Media state combined from active streams and policy state. */
     } notifier;
 };
 
@@ -162,5 +175,9 @@ bool mv_high_volume(struct mv_userdata *u);
 
 /* Return true if currently active media steps have high volume step defined. */
 bool mv_has_high_volume(struct mv_userdata *u);
+
+
+bool mv_media_state_from_string(const char *str, media_state_t *state);
+const char *mv_media_state_from_enum(media_state_t state);
 
 #endif


### PR DESCRIPTION
Add new property string MediaState to MainVolume D-Bus API.

The property can have following states:

MediaState      | Explanation
----------------|----------------------------------------------------
"inactive"      | No media streams.
                |
"foreground"    | No media streams active, but media application is
                | topmost application.
                |
"background"    | Media stream active, and the media application is not
                | topmost application.
                |
"active"        | Media stream active, and the media application is
                | topmost application.