### PR TITLE
Fix listening time notifier signalling wrong step.

### DIFF
--- a/src/mainvolume/mainvolume.c
+++ b/src/mainvolume/mainvolume.c
@@ -301,10 +301,32 @@ bool mv_high_volume(struct mv_userdata *u) {
 bool mv_has_high_volume(struct mv_userdata *u) {
     pa_assert(u);
 
-    if (u->call_active)
+    if (u->call_active || !u->notifier.mode_active)
         return false;
 
     if (u->current_steps && u->current_steps->high_volume_step > -1)
+        return true;
+    else
+        return false;
+}
+
+void mv_notifier_update_route(struct mv_userdata *u, const char *route)
+{
+    pa_assert(u);
+    pa_assert(route);
+    pa_assert(u->notifier.modes);
+
+    if (pa_hashmap_get(u->notifier.modes, u->route))
+        u->notifier.mode_active = true;
+    else
+        u->notifier.mode_active = false;
+}
+
+bool mv_notifier_active(struct mv_userdata *u)
+{
+    pa_assert(u);
+
+    if (u->notifier.mode_active && u->notifier.enabled_slots && !u->call_active)
         return true;
     else
         return false;

--- a/src/mainvolume/mainvolume.h
+++ b/src/mainvolume/mainvolume.h
@@ -176,6 +176,10 @@ bool mv_high_volume(struct mv_userdata *u);
 /* Return true if currently active media steps have high volume step defined. */
 bool mv_has_high_volume(struct mv_userdata *u);
 
+/* Update notifier state based on route. */
+void mv_notifier_update_route(struct mv_userdata *u, const char *route);
+bool mv_notifier_active(struct mv_userdata *u);
+
 
 bool mv_media_state_from_string(const char *str, media_state_t *state);
 const char *mv_media_state_from_enum(media_state_t state);


### PR DESCRIPTION
Listening time notifier should signal 0 when listening time notifier is
disabled. However if high volume step is defined for volume steps, that
value vas signalled instead of 0 even if active route wasn't listed in
mode-list. This commit fixes the functionality so that high volume step
is signalled only if the route has listening time notifier enabled and
route has high volume step defined.
